### PR TITLE
Use purge CSS config to put back some "still purged" styles…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/hankchizljaw/modern-css-reset v0.0.0-20210118105237-e7500a6c7fa3 // indirect
 	gitlab.com/goodimpact/every-layout-css v0.0.0-20211221221050-b7779e404e38 // indirect
 	gitlab.com/goodimpact/every-layout-wc v0.0.0-20210715225714-a9629e5e8f4a // indirect
-	gitlab.com/goodimpact/goodimpact-hugo/modules/base-structure v0.0.0-20221129152846-46522a4a2aeb // indirect
+	gitlab.com/goodimpact/goodimpact-hugo/modules/base-structure v0.0.0-20221129171738-d8c79a5e4c78 // indirect
 	gitlab.com/neotericdesign-tools/hugo-content-module-style-guides.git v0.0.0-20200513165827-e43fa80f0593 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,9 +5,9 @@ gitlab.com/goodimpact/every-layout-css v0.0.0-20211221221050-b7779e404e38 h1:ppD
 gitlab.com/goodimpact/every-layout-css v0.0.0-20211221221050-b7779e404e38/go.mod h1:cBM2FnF4tvjSUw+eWlCQ9Pt9eMGguyvm4CwzAcYalys=
 gitlab.com/goodimpact/every-layout-wc v0.0.0-20210715225714-a9629e5e8f4a h1:gMph7SlpLA/2VtLQBuGQ7xw6RzFrxkqtmlsnnx801XA=
 gitlab.com/goodimpact/every-layout-wc v0.0.0-20210715225714-a9629e5e8f4a/go.mod h1:JI47MJnTDNgIXwh0bRHdTtRW44zurYCeiOE3GVExCz4=
-gitlab.com/goodimpact/goodimpact-hugo/modules/base-structure v0.0.0-20221125154259-22804a83d386 h1:471Q9Qn53ML6L87ZnbFCvo26BWcGk2z0GsXRKatPfuA=
-gitlab.com/goodimpact/goodimpact-hugo/modules/base-structure v0.0.0-20221125154259-22804a83d386/go.mod h1:AKUEPPZ4fZLw+a5GxbkvWq5gnHjJam/3sNb4i0s0imY=
 gitlab.com/goodimpact/goodimpact-hugo/modules/base-structure v0.0.0-20221129152846-46522a4a2aeb h1:ebR/7XS38bwhk1VuocG5ZmADd3P+Txrow9lD86RQdsA=
 gitlab.com/goodimpact/goodimpact-hugo/modules/base-structure v0.0.0-20221129152846-46522a4a2aeb/go.mod h1:AKUEPPZ4fZLw+a5GxbkvWq5gnHjJam/3sNb4i0s0imY=
+gitlab.com/goodimpact/goodimpact-hugo/modules/base-structure v0.0.0-20221129171738-d8c79a5e4c78 h1:KzgfGSaVbzT4jKU67xx7TlhO83H6JaVagMH24OwZTjE=
+gitlab.com/goodimpact/goodimpact-hugo/modules/base-structure v0.0.0-20221129171738-d8c79a5e4c78/go.mod h1:AKUEPPZ4fZLw+a5GxbkvWq5gnHjJam/3sNb4i0s0imY=
 gitlab.com/neotericdesign-tools/hugo-content-module-style-guides.git v0.0.0-20200513165827-e43fa80f0593 h1:wEtKbagCP4B6/xs8K+bQSI2r7Z6fIMEr2VApOgUqUXE=
 gitlab.com/neotericdesign-tools/hugo-content-module-style-guides.git v0.0.0-20200513165827-e43fa80f0593/go.mod h1:p+A5GOjgLL7ajjbNwmRajJEhZ0ccEq+zLJAPkql0qs8=


### PR DESCRIPTION
Update module base-structure + clean go.sum

To see the effect, check if CSS definition `.box-l.--s2p0` is in the CSS bundle (it needs to be in)