### PR TITLE
Fix outline on focused logos in the footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -27,32 +27,17 @@
 							{{- end }}
 						</ul>
 					</div>
-					<div>
-						<a
-							href="https://neutral-it.com/"
-							target="_blank"
-							title="{{ i18n `NeutralIT` }} – {{ i18n `NewWindow` }}"
-							>{{- $logoResource := resources.Get "images/logo-neutral-it.webp" -}}
-							<img
-								src="{{- $logoResource.RelPermalink -}}"
-								width="50"
-								height="50"
-								alt="{{ i18n `NeutralIT` }}"
-						/></a>
-					</div>					
-					<div>
-						<a
-							href="https://www.greenit.fr/"
-							target="_blank"
-							title="{{ i18n `GreenITAssociation` }} – {{ i18n `NewWindow` }}"
-							>{{- $logoResource := resources.Get "images/logo-greenit.svg" -}}
-							<img
-								src="{{- $logoResource.RelPermalink -}}"
-								width="126"
-								height="50"
-								alt="{{ i18n `GreenITAssociation` }}"
-						/></a>
-					</div>
+					<a href="https://neutral-it.com/" target="_blank" title="{{ i18n `NeutralIT` }} – {{ i18n `NewWindow` }}"
+						>{{- $logoResource := resources.Get "images/logo-neutral-it.webp" -}}
+						<img src="{{- $logoResource.RelPermalink -}}" width="50" height="50" alt="{{ i18n `NeutralIT` }}"
+					/></a>
+					<a
+						href="https://www.greenit.fr/"
+						target="_blank"
+						title="{{ i18n `GreenITAssociation` }} – {{ i18n `NewWindow` }}"
+						>{{- $logoResource := resources.Get "images/logo-greenit.svg" -}}
+						<img src="{{- $logoResource.RelPermalink -}}" width="126" height="50" alt="{{ i18n `GreenITAssociation` }}"
+					/></a>
 				</nav>
 			</div>
 		</footer>


### PR DESCRIPTION
Before: outline not visible on focus (because of some margins)

After: outline visible on focus

Fix #217 