### PR TITLE
Display Full URL in Results and Make it Clickable

### DIFF
--- a/assets/css/51_page-result.css
+++ b/assets/css/51_page-result.css
@@ -2,32 +2,6 @@
  * RESULT PAGE SPECIFIC STYLES
  */
 
- .result-url-wrapper {
-	font-weight: var(--font-weight-bold);
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
- }
-
- /**
-  * For small screens, put the URL on a new line,
-  * and move truncate feature from the wrapper to the URL.
-  */
- @media (max-width: 60rem) {
-	.result-url-wrapper {
-		overflow: auto;
-		text-overflow: initial;
-		white-space: initial;
-	}
-
-	.result-url {
-		display: block;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
- }
-
 /*! purgecss start ignore */
 .result-badge {
 	font-size: var(--s2);

--- a/assets/css/51_page-result.css
+++ b/assets/css/51_page-result.css
@@ -2,6 +2,32 @@
  * RESULT PAGE SPECIFIC STYLES
  */
 
+ .result-url-wrapper {
+	font-weight: var(--font-weight-bold);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+ }
+
+ /**
+  * For small screens, put the URL on a new line,
+  * and move truncate feature from the wrapper to the URL.
+  */
+ @media (max-width: 60rem) {
+	.result-url-wrapper {
+		overflow: auto;
+		text-overflow: initial;
+		white-space: initial;
+	}
+
+	.result-url {
+		display: block;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+ }
+
 /*! purgecss start ignore */
 .result-badge {
 	font-size: var(--s2);

--- a/assets/js/components/SiteAnalysisResult.js
+++ b/assets/js/components/SiteAnalysisResult.js
@@ -197,7 +197,7 @@ class SiteAnalysisResult {
 		let formatedValue;
 		// Format date
 		formatedValue = this._getValidDateString(elementValue);
-		formatedValue = formatedValue ? formatedValue : getUrlHostName(elementValue);
+		formatedValue = formatedValue ? formatedValue : elementValue;
 		return formatedValue ? formatedValue : elementValue;
 	}
 

--- a/assets/js/components/SiteAnalysisResult.js
+++ b/assets/js/components/SiteAnalysisResult.js
@@ -115,6 +115,7 @@ class SiteAnalysisResult {
 		this._setDomContent(pageResultData, "data-int", "data-int-attr");
 
 		// specific components updates
+		this._updateUrl(pageResultData.url)
 		this._updateNoteChart(pageResultData.grade);
 		this._updateFootprintResultsFromSelect();
 		this._updatetResultRangeSliders(pageResultData);
@@ -259,6 +260,17 @@ class SiteAnalysisResult {
 	_updatetResultRangeSliders(data) {
 		const sliderEls = document.querySelectorAll(".js-rlr");
 		sliderEls.forEach((sliderEl) => new ResultRangeSlider({ sliderEl, data }));
+	}
+
+	/**
+	 * Update the href and title attribute of the element that contains the analyzed URL
+	 * @param {string} url
+	 */
+	_updateUrl(url) {
+		const urlElement = this.el.querySelector(".result-url")
+		
+		urlElement.setAttribute("href", url)
+		urlElement.setAttribute("title", url)
 	}
 }
 export default SiteAnalysisResult;

--- a/assets/js/components/SiteAnalysisResult.js
+++ b/assets/js/components/SiteAnalysisResult.js
@@ -269,8 +269,7 @@ class SiteAnalysisResult {
 	_updateUrl(url) {
 		const urlElement = this.el.querySelector(".result-url")
 		
-		urlElement.setAttribute("href", url)
-		urlElement.setAttribute("title", url)
+		urlElement.setAttribute("value", url)
 	}
 }
 export default SiteAnalysisResult;

--- a/content/en/result/_#first_intro.md
+++ b/content/en/result/_#first_intro.md
@@ -3,8 +3,10 @@ id="intro"
 widget="result-intro"
 +++
 
-Calculated on {{< result-date >}}
+Calculated 
 
 <h1 class="h2 result-url-wrapper">
-Results for {{< result-url >}}
+    Results from {{< result-date >}}
 </h1>
+
+{{< result-url >}}

--- a/content/en/result/_#first_intro.md
+++ b/content/en/result/_#first_intro.md
@@ -5,6 +5,6 @@ widget="result-intro"
 
 Calculated on {{< result-date >}}
 
-<h1 class="h2 font-weight:semi-bold">
+<h1 class="h2 result-url-wrapper">
 Results for {{< result-url >}}
 </h1>

--- a/content/en/result/_#first_intro.md
+++ b/content/en/result/_#first_intro.md
@@ -3,10 +3,10 @@ id="intro"
 widget="result-intro"
 +++
 
-Calculated 
+Calculated on {{< result-date >}}
 
-<h1 class="h2 result-url-wrapper">
-    Results from {{< result-date >}}
+<h1 class="h2 font-weight:semi-bold">
+   Analysis results
 </h1>
 
 {{< result-url >}}

--- a/content/fr/result/_#first_intro.md
+++ b/content/fr/result/_#first_intro.md
@@ -3,8 +3,10 @@ id="intro"
 widget="result-intro"
 +++
 
-<h1 class="h2 result-url-wrapper">
-    Résultat du {{< result-date >}}
+Calculé le {{< result-date >}}
+
+<h1 class="h2 font-weight:semi-bold">
+   Résultats de l’analyse
 </h1>
 
 {{< result-url >}}

--- a/content/fr/result/_#first_intro.md
+++ b/content/fr/result/_#first_intro.md
@@ -3,8 +3,8 @@ id="intro"
 widget="result-intro"
 +++
 
-Calculé le {{< result-date >}}
-
 <h1 class="h2 result-url-wrapper">
-    Résultat pour {{< result-url >}}
+    Résultat du {{< result-date >}}
 </h1>
+
+{{< result-url >}}

--- a/content/fr/result/_#first_intro.md
+++ b/content/fr/result/_#first_intro.md
@@ -5,6 +5,6 @@ widget="result-intro"
 
 Calculé le {{< result-date >}}
 
-<h1 class="h2 font-weight:semi-bold">
-Résultat pour {{< result-url >}}
+<h1 class="h2 result-url-wrapper">
+    Résultat pour {{< result-url >}}
 </h1>

--- a/layouts/partials/components/result-url.html
+++ b/layouts/partials/components/result-url.html
@@ -1,1 +1,15 @@
-<a class="result-url" data-int="url" href="#" rel="nofollow" title="#"></a>
+<p class="stack-l">
+    <input class="result-url" data-int="url">
+    <span>
+        <a href="/" class="button-default js-button-retest"
+            ><span class="icon-square-wrapper bg-darkish" aria-label="{{ i18n `ReTest` }}"
+                >{{ partial "svg/inline-svg-use" "icon-refresh" }}</span
+            >&nbsp;<span class="hide-mobile">{{ i18n `ReTest` }}</span></a
+        >
+        <a id="share-btn" href="/" role="button" class="button-default"
+            ><span class="icon-square-wrapper bg-darkish" aria-label="{{ i18n `Share` }}"
+                >{{ partial "svg/inline-svg-use" "icon-share" }}</span
+            >&nbsp;<span class="hide-mobile">{{ i18n `Share` }}</span></a
+        >
+    </span>
+</p>

--- a/layouts/partials/components/result-url.html
+++ b/layouts/partials/components/result-url.html
@@ -1,1 +1,1 @@
-<input class="result-url" data-int="url">
+<input class="result-url" disabled data-int="url">

--- a/layouts/partials/components/result-url.html
+++ b/layouts/partials/components/result-url.html
@@ -1,1 +1,1 @@
-<span class="result-url" data-int="url"></span>
+<a class="result-url" data-int="url" href="#" rel="nofollow" title="#"></a>

--- a/layouts/partials/components/result-url.html
+++ b/layouts/partials/components/result-url.html
@@ -1,15 +1,1 @@
-<p class="stack-l">
-    <input class="result-url" data-int="url">
-    <span>
-        <a href="/" class="button-default js-button-retest"
-            ><span class="icon-square-wrapper bg-darkish" aria-label="{{ i18n `ReTest` }}"
-                >{{ partial "svg/inline-svg-use" "icon-refresh" }}</span
-            >&nbsp;<span class="hide-mobile">{{ i18n `ReTest` }}</span></a
-        >
-        <a id="share-btn" href="/" role="button" class="button-default"
-            ><span class="icon-square-wrapper bg-darkish" aria-label="{{ i18n `Share` }}"
-                >{{ partial "svg/inline-svg-use" "icon-share" }}</span
-            >&nbsp;<span class="hide-mobile">{{ i18n `Share` }}</span></a
-        >
-    </span>
-</p>
+<input class="result-url" data-int="url">

--- a/layouts/partials/widgets/result-intro.html
+++ b/layouts/partials/widgets/result-intro.html
@@ -7,18 +7,6 @@
 						>{{ partial "svg/inline-svg-use" "icon-arrow-left" }}&nbsp;{{ i18n `Back` }}</a
 					>
 				</div>
-				<div class="display:flex justify-content:end text-align:end">
-					<a href="/" class="button-default js-button-retest"
-						><span class="icon-square-wrapper bg-darkish" aria-label="{{ i18n `ReTest` }}"
-							>{{ partial "svg/inline-svg-use" "icon-refresh" }}</span
-						>&nbsp;<span class="hide-mobile">{{ i18n `ReTest` }}</span></a
-					>
-					<a id="share-btn" href="/" role="button" class="button-default"
-						><span class="icon-square-wrapper bg-darkish" aria-label="{{ i18n `Share` }}"
-							>{{ partial "svg/inline-svg-use" "icon-share" }}</span
-						>&nbsp;<span class="hide-mobile">{{ i18n `Share` }}</span></a
-					>
-				</div>
 			</div>
 		</div>
 		<div class="stack-l">

--- a/layouts/partials/widgets/result-intro.html
+++ b/layouts/partials/widgets/result-intro.html
@@ -7,6 +7,19 @@
 						>{{ partial "svg/inline-svg-use" "icon-arrow-left" }}&nbsp;{{ i18n `Back` }}</a
 					>
 				</div>
+
+				<div class="display:flex justify-content:end text-align:end">
+					<a href="/" class="button-default js-button-retest"
+						><span class="icon-square-wrapper bg-darkish" aria-label="{{ i18n `ReTest` }}"
+							>{{ partial "svg/inline-svg-use" "icon-refresh" }}</span
+						>&nbsp;<span class="hide-mobile">{{ i18n `ReTest` }}</span></a
+					>
+					<a id="share-btn" href="/" role="button" class="button-default"
+						><span class="icon-square-wrapper bg-darkish" aria-label="{{ i18n `Share` }}"
+							>{{ partial "svg/inline-svg-use" "icon-share" }}</span
+						>&nbsp;<span class="hide-mobile">{{ i18n `Share` }}</span></a
+					>
+				</div>
 			</div>
 		</div>
 		<div class="stack-l">


### PR DESCRIPTION
## **User description**
Fixes https://github.com/cnumr/EcoIndex/issues/250


___

## **Type**
Enhancement


___

## **Description**
This PR introduces several enhancements to the way URLs are displayed in the results:
- The full URL is now displayed instead of just the hostname.
- The URL is made clickable by changing the `span` element to an `a` element.
- New CSS rules have been added to handle the display of the full URL on different screen sizes.
- The `ResultScore` and `ResultScoreExplainationKnowMore` i18n strings now use `safeHTML` to correctly display HTML characters.
- The `h1` tags in the result intro content for both English and French have been updated to use the new `result-url-wrapper` class.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SiteAnalysisResult.js&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        assets/js/components/SiteAnalysisResult.js<br><br>

**Added a new method `_updateUrl` to update the href and title <br>attribute of the element that contains the analyzed URL. <br>Also, updated the `_getDataValueFrom` method to return the <br>full URL instead of just the hostname.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/cnumr/EcoIndex/pull/252/files#diff-2e616d4654e7b9a98e2c2e0593c4b520eaee5729d823f9886eea97b03eff362a"> +13/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>result-url.html&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        layouts/partials/components/result-url.html<br><br>

**The `span` element with class `result-url` has been replaced <br>with an `a` element to make the URL clickable.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/cnumr/EcoIndex/pull/252/files#diff-fb5e2f59c07c54e8029657d352e19c8544f45b701f5e4a18a1bc746a0e610ec1"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>51_page-result.css&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        assets/css/51_page-result.css<br><br>

**Added new CSS rules for `.result-url-wrapper` and <br>`.result-url` to handle the display of the full URL in <br>different screen sizes.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/cnumr/EcoIndex/pull/252/files#diff-4346280b6bb5d109d353c203624a278d5de11dd05d9439163bdcfcdcaaa60363"> +26/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>_#first_intro.md&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        content/en/result/_#first_intro.md<br><br>

**Updated the `h1` tag to use the class `result-url-wrapper` <br>for displaying the full URL.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/cnumr/EcoIndex/pull/252/files#diff-f7714a1f183a11fc9669d35adc70e809c1d204b25b4f18012d9426bd009723ec"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>_#first_intro.md&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        content/fr/result/_#first_intro.md<br><br>

**Updated the `h1` tag to use the class `result-url-wrapper` <br>for displaying the full URL.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/cnumr/EcoIndex/pull/252/files#diff-c5f901534cf401b59129b363b049b9fd5386524e42326d8fd57b53d74c87b6e0"> +2/-2</a></td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>result-appreciation.html&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        layouts/partials/widgets/result-appreciation.html<br><br>

**Updated the `ResultScore` and <br>`ResultScoreExplainationKnowMore` i18n strings to use <br>`safeHTML`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/cnumr/EcoIndex/pull/252/files#diff-af2c05743c25cd5336397d0c863b6a0aacecee447e1df732e4e35037605ba428"> +2/-2</a></td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
