### PR TITLE
📝 doc(toolbox): Mise à jour de la documentation toolbox

### DIFF
--- a/content/en/eco-design/_40_tools.md
+++ b/content/en/eco-design/_40_tools.md
@@ -1,28 +1,93 @@
 +++
-id = "tools"
+id="tools"
 weight = 40
 +++
 
-## La boîte à outils
+{{% info_2_columns %}}
 
-[**WARNING !!! A passer en anglais**]
+{{% info_2_columns_col1 %}}
 
-### ECOMETER | Evaluez l’application des bonnes pratiques
+## The toolbox
 
-Si EcoIndex teste la performance et l’empreinte environnementale d’une page web, Ecometer évalue votre niveau de
-maturité au regard des bonnes pratiques d’écoconception. Vous connaîtrez les critères atteints... et ceux qui restent à
-travailler 🔨 [Ecometer](http://www.ecometer.org/)
+{{% /info_2_columns_col1 %}}
 
-### EXTENSIONS | EcoIndex et Ecometer dans la poche
+{{% info_2_columns_col2 %}}
 
-EcoIndex et Ecometer sont unis dans une même extension ! Sur Chrome et Firefox, vous pouvez tester la performance et
-l’empreinte de n’importe quelle page web et constituer un historique pour reproduire le parcours de vos
-utilisateur·ices. Si pratique !
-[GreenIT Analysis - Chrome](https://chrome.google.com/webstore/detail/greenit-analysis/mofbfhffeklkbebfclfaiifefjflcpad)
-[GreenIT Analysis - Firefox](https://addons.mozilla.org/fr/firefox/addon/greenit-analysis/)
+### Browser plugins
 
-### GITHUB | A vous de jouer
+#### Green IT Analysis | EcoIndex in the pocket
 
-EcoIndex est un projet communautaire et open source qui ne demande qu’à être enrichi via la contribution d’experts et
-passionné·es. Vous pouvez consulter à tout moment le GitHub du projet afin de mieux le comprendre et, pourquoi pas, d’y
-participer ! [Github](https://github.com/cnumr/EcoIndex)
+EcoIndex and some good practices are united in the same extension! On Chrome and Firefox, you can test
+the environmental footprint of any web page and build a history to reproduce the path of your
+users. So practical!
+<p>
+{{% content_link href="https://chrome.google.com/webstore/detail/greenit-analysis/mofbfhffeklkbebfclfaiifefjflcpad?hl=fr" %}}Chrome extension{{% /content_link %}}
+<br>
+{{% content_link href="https://addons.mozilla.org/fr/firefox/addon/greenit-analysis/" %}}Firefox extension{{% /content_link %}}
+</p>
+
+Contribute the source code by going to the [Greenit Analysis Plugin GitHub](https://github.com/cnumr/GreenIT-Analysis)
+
+#### The Ecoindex plugin
+
+The Ecoindex plugin allows you to display the existing ecoindex score in the database of the ecoindex.fr site of a web page in the browser. It is available for Firefox, Chrome, Edge and Opera. It will allow you to see the latest ratings for the same page, but also the ratings on the other pages of your site. Finally, it simplifies the analysis of a page:
+
+<p>
+{{% content_link href="https://chrome.google.com/webstore/detail/ecoindexen/apeadjelacokohnkfclnhjlihklpclmp" %}}Chrome Extension{{% /content_link %}}
+<br>
+{{% content_link href="https://addons.mozilla.org/fr/firefox/addon/ecoindex-fr/" %}}Firefox extension{{% /content_link %}}
+<br>
+{{% content_link href="https://microsoftedge.microsoft.com/addons/detail/fioadgdggjngcpbeilfgacmddamnhnah" %}}Edge Extension{{% /content_link %}}
+<br>
+{{% content_link href="https://addons.opera.com/fr/extensions/details/ecoindexfr/" %}}Opera extension{{% /content_link %}}
+</p>
+
+Contribute the source code by going to the [Ecoindex plugin GitHub](https://github.com/cnumr/ecoindex-browser-plugin)
+
+#### Why different results between these 2 plugins?
+
+The 2 plugins have different operating modes to perform analyzes and the results may therefore differ from one tool to another:
+
+- The Greenit Analysis plugin works in your browser taking into account the current context of the user (IP address, browser Plugins installed, cache, session cookies...). More details on the [plugin documentation](https://github.com/cnumr/GreenIT-Analysis#r%C3%A9sultats-diff%C3%A9rents-entre-deux-analyses)
+- The Ecoindex plugin uses the ecoindex.fr API which will open a blank chrome browser on each analysis with a predefined scenario. More details on the [operation of the API](https://www.ecoindex.fr/comment-ca-marche/#m%C3%A9thodologie-danalyse)
+
+### The Ecoindex badge
+
+The Ecoindex badge makes it easy to display the ecoindex score on your page. To do this, simply add an html code to your page.
+
+<p>
+{{% content_link href="https://github.com/cnumr/ecoindex_badge" %}}The Ecoindex badge project page{{% /content_link %}}
+</p>
+
+### Ecoindex command line
+
+The Ecoindex CLI project makes it possible to launch an analysis of a web page from the command line. Developed in python, it is available for Linux, Mac and Windows. It will allow you to launch an analysis of a page or a set of pages, generate a result file in csv or json format, generate an HTML report...
+
+<p>
+{{% content_link href="https://github.com/cnumr/ecoindex_cli" %}}The Ecoindex CLI project page{{% /content_link %}}
+</p>
+
+### GitHub | Up to you
+
+EcoIndex is a community and open source project that only asks to be enriched through the contribution of experts and
+passionate. You can consult the GitHub of the project at any time in order to better understand it and, why not, to
+participate !
+<p>
+{{% content_link href="https://github.com/cnumr" %}}GitHub Cnumr{{% /content_link %}}
+<br>
+{{% content_link href="https://github.com/cnumr/EcoIndex" %}}GitHub frontend site EcoIndex{{% /content_link %}}
+<br>
+{{% content_link href="https://github.com/cnumr/ecoindex_api" %}}GitHub backend site EcoIndex{{% /content_link %}}
+<br>
+{{% content_link href="https://github.com/cnumr/GreenIT-Analysis" %}}GitHub plugin GreenIT Analysis{{% /content_link %}}
+<br>
+{{% content_link href="https://github.com/cnumr/ecoindex-browser-plugin" %}}GitHub Ecoindex plugin{{%/content_link %}}
+<br>
+{{% content_link href="https://github.com/cnumr/ecoindex_badge" %}}GitHub Ecoindex badge{{%/content_link %}}
+<br>
+{{% content_link href="https://github.com/cnumr/ecoindex_cli" %}}GitHub CLI Ecoindex{{%/content_link %}}
+</p>
+
+{{% /info_2_columns_col2 %}}
+
+{{% /info_2_columns %}}

--- a/content/fr/eco-design/_40_outils.md
+++ b/content/fr/eco-design/_40_outils.md
@@ -13,7 +13,9 @@ weight = 40
 
 {{% info_2_columns_col2 %}}
 
-### GreenIT Analysis | EcoIndex dans la poche
+### Les plugins navigateurs
+
+#### GreenIT Analysis | EcoIndex dans la poche
 
 EcoIndex et certaines bonnes pratiques sont unis dans une même extension ! Sur Chrome et Firefox, vous pouvez tester
 l’empreinte environnementale de n’importe quelle page web et constituer un historique pour reproduire le parcours de vos
@@ -22,19 +24,69 @@ utilisateur·ices. Si pratique !
 {{% content_link href="https://chrome.google.com/webstore/detail/greenit-analysis/mofbfhffeklkbebfclfaiifefjflcpad?hl=fr" %}}Extension Chrome{{% /content_link %}}
 <br>
 {{% content_link href="https://addons.mozilla.org/fr/firefox/addon/greenit-analysis/" %}}Extension Firefox{{% /content_link %}}
-<br> 
-{{% content_link href="https://github.com/cnumr/ecoindex_cli" %}}En ligne de commande{{% /content_link %}}
+</p>
+
+Contribuez au code source en allant sur le [GitHub du plugin Greenit Analysis](https://github.com/cnumr/GreenIT-Analysis)
+
+#### Le plugin Ecoindex
+
+Le plugin Ecoindex permet d'afficher le score écoindex existant dans la base de données du site ecoindex.fr d'une page web dans le navigateur. Il est disponible pour Firefox, Chrome, Edge et Opera. Il vous permettra de voir les dernières notes pour une même page, mais également les notes sur les autres pages de votre site. Enfin, il simplifie l'analyse d'une page:
+
+<p>
+{{% content_link href="https://chrome.google.com/webstore/detail/ecoindexfr/apeadjelacokohnkfclnhjlihklpclmp" %}}Extension Chrome{{% /content_link %}}
+<br>
+{{% content_link href="https://addons.mozilla.org/fr/firefox/addon/ecoindex-fr/" %}}Extension Firefox{{% /content_link %}}
+<br>
+{{% content_link href="https://microsoftedge.microsoft.com/addons/detail/fioadgdggjngcpbeilfgacmddamnhnah" %}}Extension Edge{{% /content_link %}}
+<br>
+{{% content_link href="https://addons.opera.com/fr/extensions/details/ecoindexfr/" %}}Extension Opera{{% /content_link %}}
+</p>
+
+Contribuez au code source en allant sur le [GitHub du plugin Ecoindex](https://github.com/cnumr/ecoindex-browser-plugin)
+
+#### Pourquoi des résultats différents entre ces 2 plugins ?
+
+Les 2 plugins ont des modes de fonctionnement différents pour effectuer des analyses et les résultats peuvent donc différer d'un outil à l'autre:
+
+- Le plugin Greenit Analysis fonctionne dans votre navigateur en tenant compte du contexte actuel de l'utilisateur (Adresse IP, navigateur Plugins installés, cache, cookies de session...). Plus de précisions sur la [documentation du plugin](https://github.com/cnumr/GreenIT-Analysis#r%C3%A9sultats-diff%C3%A9rents-entre-deux-analyses)
+- Le plugin Ecoindex utilise l'API ecoindex.fr qui va ouvrir un navigateur chrome vierge à  chaque analyse avec un scenario prédéfini. Plus de précisions sur le [fonctionnement de l'API](https://www.ecoindex.fr/comment-ca-marche/#m%C3%A9thodologie-danalyse)
+
+### Le badge Ecoindex
+
+Le badge Ecoindex permet d'afficher le score écoindex simplement sur votre page. Pour celà, il suffit d'ajouter un code html dans votre page.
+
+<p>
+{{% content_link href="https://github.com/cnumr/ecoindex_badge" %}}La page du projet badge Ecoindex{{% /content_link %}}
+</p>
+
+### Ecoindex en ligne de commande
+
+Le projet Ecoindex CLI permet de lancer une analyse d'une page web en ligne de commande. Développé en python, il est disponible pour Linux, Mac et Windows. Il vous permettra lancer une analyse d'une page ou d'un ensemble de pages, générer un fichier de résultat au format csv ou json, générer un rapport HTML...
+
+<p>
+{{% content_link href="https://github.com/cnumr/ecoindex_cli" %}}La page du projet Ecoindex CLI{{% /content_link %}}
 </p>
 
 ### GitHub | A vous de jouer
 
 EcoIndex est un projet communautaire et open source qui ne demande qu’à être enrichi via la contribution d’experts et
 passionné·es. Vous pouvez consulter à tout moment le GitHub du projet afin de mieux le comprendre et, pourquoi pas, d’y
-participer ! 
+participer !
 <p>
-{{% content_link href="https://github.com/cnumr/EcoIndex" %}}GitHub Cnumr{{% /content_link %}}
+{{% content_link href="https://github.com/cnumr" %}}GitHub Cnumr{{% /content_link %}}
+<br>
+{{% content_link href="https://github.com/cnumr/EcoIndex" %}}GitHub frontend site EcoIndex{{% /content_link %}}
+<br>
+{{% content_link href="https://github.com/cnumr/ecoindex_api" %}}GitHub backend site EcoIndex{{% /content_link %}}
+<br>
+{{% content_link href="https://github.com/cnumr/GreenIT-Analysis" %}}GitHub plugin GreenIT Analysis{{% /content_link %}}
+<br>
+{{% content_link href="https://github.com/cnumr/ecoindex-browser-plugin" %}}GitHub plugin Ecoindex{{% /content_link %}}
+<br>
+{{% content_link href="https://github.com/cnumr/ecoindex_badge" %}}GitHub badge Ecoindex{{% /content_link %}}
+<br>
+{{% content_link href="https://github.com/cnumr/ecoindex_cli" %}}GitHub CLI Ecoindex{{% /content_link %}}
 </p>
-
 
 {{% /info_2_columns_col2 %}}
 


### PR DESCRIPTION
Faut il également modifier le fichier `content/en/result/_70_extension.md` (et fr) pour  mentionner le plugin Ecoindex ? Ou faut il n'en nommer qu'un seul ?