### PR TITLE
feat: display the screenshot of the webpage that has been analyzed

### DIFF
--- a/assets/js/components/SiteAnalysisResult.js
+++ b/assets/js/components/SiteAnalysisResult.js
@@ -39,6 +39,7 @@ class SiteAnalysisResult {
 	async _init() {
 		const urlParams = new URLSearchParams(window.location.search);
 		const langSwitchersElements = document.querySelectorAll(".language-switcher a.lang")
+		const screenshotImgElement = document.querySelector(".result-screenshot")
 
 		let pageResultData = {};
 
@@ -58,13 +59,19 @@ class SiteAnalysisResult {
 			// else fetch analysis result from id
 			// NOTE : url params example to test : "?id=ec839aca-7c12-42e8-8541-5f7f94c36b7f
 		} else if (urlParams.has("id")) {
-			const id = urlParams.get("id");
+			const analysisId = urlParams.get("id");
+
 			// window.location.pathname is something like /resultat (in french) or /en/result (in english)
-			pageResultData = await AnalysisService.fetchAnalysisById(id, window.location.pathname);
+			pageResultData = await AnalysisService.fetchAnalysisById(analysisId, window.location.pathname)
+
+			try {
+				const screenshotDataUri = await AnalysisService.fetchAnalysisScreenshotById(analysisId)
+				screenshotImgElement.setAttribute("src", screenshotDataUri)
+			} catch (error) {} // we don't care if the screenshot cannot be fetch: the user will have a blanck rectangle instead but the results are still accessible
 
 			// update the link URL of every lang switcher
 			langSwitchersElements.forEach((a) => {
-				const href = a.getAttribute("href") + "?id=" + id
+				const href = a.getAttribute("href") + "?id=" + analysisId
 				a.setAttribute("href", href)
 			})
 		} else {

--- a/assets/js/components/SiteAnalysisResult.js
+++ b/assets/js/components/SiteAnalysisResult.js
@@ -64,10 +64,8 @@ class SiteAnalysisResult {
 			// window.location.pathname is something like /resultat (in french) or /en/result (in english)
 			pageResultData = await AnalysisService.fetchAnalysisById(analysisId, window.location.pathname)
 
-			try {
-				const screenshotDataUri = await AnalysisService.fetchAnalysisScreenshotById(analysisId)
-				screenshotImgElement.setAttribute("src", screenshotDataUri)
-			} catch (error) {} // we don't care if the screenshot cannot be fetch: the user will have a blanck rectangle instead but the results are still accessible
+			const screenshotUrl = AnalysisService.fetchAnalysisScreenshotUrlById(analysisId)
+			screenshotImgElement.setAttribute("src", screenshotUrl)
 
 			// update the link URL of every lang switcher
 			langSwitchersElements.forEach((a) => {

--- a/assets/js/components/SiteAnalysisResult.js
+++ b/assets/js/components/SiteAnalysisResult.js
@@ -48,6 +48,11 @@ class SiteAnalysisResult {
 		if (urlParams.has("url") && urlParams.has("size") && urlParams.has("ges")) {
 			for (const [key, value] of urlParams.entries()) {
 				pageResultData[key] = value;
+
+				if (key === "id") {
+					const screenshotUrl = AnalysisService.fetchAnalysisScreenshotUrlById(urlParams.get("id"))
+					screenshotImgElement.setAttribute("src", screenshotUrl)
+				}
 			}
 
 			// update the link URL of every lang switcher

--- a/assets/js/services/AnalysisService.js
+++ b/assets/js/services/AnalysisService.js
@@ -57,6 +57,15 @@ class AnalysisService {
 	}
 
 	/**
+	 * Do not use this.#handleError as we do not want to trigger the error modal if this fetch fails.
+	 * @param {string} id 
+	 * @returns {Promise<string | ArrayBuffer>}
+	 */
+	async fetchAnalysisScreenshotById(id) {
+		return ApiService.fetchAnalysisScreenshotById(id)
+	}
+
+	/**
 	 * 
 	 * @param {string} id
 	 * @param {string} resultPagePrefix

--- a/assets/js/services/AnalysisService.js
+++ b/assets/js/services/AnalysisService.js
@@ -57,12 +57,11 @@ class AnalysisService {
 	}
 
 	/**
-	 * Do not use this.#handleError as we do not want to trigger the error modal if this fetch fails.
 	 * @param {string} id 
-	 * @returns {Promise<string | ArrayBuffer>}
+	 * @returns {string}
 	 */
-	async fetchAnalysisScreenshotById(id) {
-		return ApiService.fetchAnalysisScreenshotById(id)
+	fetchAnalysisScreenshotUrlById(id) {
+		return ApiService.fetchAnalysisScreenshotUrlById(id)
 	}
 
 	/**

--- a/assets/js/services/ApiService.js
+++ b/assets/js/services/ApiService.js
@@ -22,7 +22,8 @@ class ApiService {
 				url,
 			},
 		};
-		return this.#fetchApi("tasks/ecoindexes", options).json();
+
+		return this.#fetchApi("tasks/ecoindexes", options);
 	}
 
 	/**
@@ -41,28 +42,16 @@ class ApiService {
 			},
 		};
 
-		return this.#fetchApi("tasks/ecoindexes/" + id, options).json();
+		return this.#fetchApi("tasks/ecoindexes/" + id, options);
 	}
 
 	/**
-	 * Request the screenshot of the analyzed page
+	 * Get the URL that generates the screenshot of the analyzed page
 	 * @param {string} id Analysis Id
-	 * @returns {Promise<string | ArrayBuffer>}
+	 * @returns {string} API URL
 	 */
-	async fetchAnalysisScreenshotById(id) {
-		const options = {
-			method: "get",
-		};
-
-		const response = await this.#fetchApi(`ecoindexes/${id}/screenshot`, options);
-		const blob = await response.blob()
-
-		return new Promise((resolve, reject) => {
-			const fileReader = new FileReader()
-			fileReader.onload = e => resolve(e.target.result);
-			fileReader.onerror = e => reject(e)
-			fileReader.readAsDataURL(blob)
-		})
+	fetchAnalysisScreenshotUrlById(id) {
+		return `${BASE_URL}ecoindexes/${id}/screenshot`;
 	}
 
 	/**
@@ -75,7 +64,8 @@ class ApiService {
 		const options = {
 			method: "get",
 		};
-		return this.#fetchApi("ecoindexes/" + id, options).json();
+
+		return this.#fetchApi("ecoindexes/" + id, options);
 	}
 
 	/**
@@ -98,7 +88,7 @@ class ApiService {
 	 * @param {string} [options.method] Method: 'post' or 'get'
 	 * @param {Object} [options.json] Object of properties to post in body (relevant for post method)
 	 * @param {Object} [options.retry] Retry object to override default Ky retry request property
-	 * @returns {import("ky").ResponsePromise} response object
+	 * @returns {Promise<import("ky").KyResponse>} response object
 	 */
 	async #fetchApi(slug, options) {
 		this.abortAnalysis();
@@ -115,7 +105,7 @@ class ApiService {
 				"content-type": "application/json",
 			},
 			redirect: "follow",
-		})
+		}).json()
 	}
 }
 

--- a/layouts/partials/widgets/result-appreciation.html
+++ b/layouts/partials/widgets/result-appreciation.html
@@ -10,6 +10,7 @@
 					{{ i18n "ResultScore" | safeHTML }} <span><span data-int="score">0</span> / 100</span>
 				</p>
 				<hr class="small" />
+				<img alt="" class="result-screenshot" height="800" loading="lazy" src="" width="1422">
 				<div class="info-collapse">
 					{{ $label := i18n "ResultScoreExplainationLabel" }}
 					{{ $content := i18n "ResultScoreExplainationContent" }}


### PR DESCRIPTION
# Todo
- [x] Displays the screenshot in the result page with the query param `id=`
- [x] Displays the screenshot in the result page with the query params `url=&size=&ges=`

# Preview
## Desktop
![image](https://github.com/cnumr/EcoIndex/assets/1890804/f65eb1cb-a38c-4337-b40a-a2e80c7f9553)

## Mobile
![Screenshot 2024-01-12 at 21-03-30 Résultat](https://github.com/cnumr/EcoIndex/assets/1890804/bf1ed2f9-c301-43ba-b711-baa3bb6c755c)

Closes #152 